### PR TITLE
Add sorting options and "Go to xxxxx" system navigation menu

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -759,7 +759,15 @@ SystemData* CollectionSystemManager::addNewCustomCollection(std::string name)
 // creates a new, empty Collection system, based on the name and declaration
 SystemData* CollectionSystemManager::createNewCollectionEntry(std::string name, CollectionSystemDecl sysDecl, bool index)
 {
-	SystemData* newSys = new SystemData(name, sysDecl.longName, mCollectionEnvData, sysDecl.themeFolder, true);
+	SystemMetadata md;
+	md.name = name;
+	md.fullName = sysDecl.longName;
+	md.themeFolder = sysDecl.themeFolder;
+	md.manufacturer = "Collections";
+	md.hardwareType = sysDecl.isCustom ? "custom collection" : "auto collection";
+	md.releaseYear = 0;
+
+	SystemData* newSys = new SystemData(md, mCollectionEnvData, true);
 
 	CollectionSystemData newCollectionData;
 	newCollectionData.system = newSys;

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -115,6 +115,71 @@ CollectionSystemManager::~CollectionSystemManager()
 	sInstance = NULL;
 }
 
+bool systemSortByAlpha(SystemData* sys1, SystemData* sys2)
+{
+	std::string name1 = Utils::String::toUpper(sys1->getFullName());
+	std::string name2 = Utils::String::toUpper(sys2->getFullName());
+	return name1.compare(name2) < 0;
+}
+
+bool systemSortByManufacturer(SystemData* sys1, SystemData* sys2)
+{
+	// Move collections to end
+	if (sys1->isCollection() != sys2->isCollection())
+		return sys2->isCollection();
+	
+	// Order by Manufacturer
+	std::string mf1 = Utils::String::toUpper(sys1->getSystemMetadata().manufacturer);
+	std::string mf2 = Utils::String::toUpper(sys2->getSystemMetadata().manufacturer);
+	if (mf1 != mf2)
+		return mf1.compare(mf2) < 0;
+
+	// Then by release date 
+	if (sys1->getSystemMetadata().releaseYear < sys2->getSystemMetadata().releaseYear)
+		return true;
+	else if (sys1->getSystemMetadata().releaseYear > sys2->getSystemMetadata().releaseYear)
+		return false;
+
+	// Then by name
+	return systemSort(sys1, sys2);
+}
+
+bool systemSortByReleaseDate(SystemData* sys1, SystemData* sys2)
+{
+	// Order by hardware
+	int mf1 = sys1->getSystemMetadata().releaseYear;
+	int mf2 = sys2->getSystemMetadata().releaseYear;
+	if (mf1 != mf2)
+		return mf1 < mf2;
+
+	// Move collection at Begin
+	if (sys1->isCollection() != sys2->isCollection())
+		return !sys2->isCollection();
+
+	// Then by name
+	std::string name1 = Utils::String::toUpper(sys1->getName());
+	std::string name2 = Utils::String::toUpper(sys2->getName());
+	return name1.compare(name2) < 0;
+}
+
+bool systemSortByHardware(SystemData* sys1, SystemData* sys2)
+{
+	// Move collection at End
+	if (sys1->isCollection() != sys2->isCollection())
+		return sys2->isCollection();
+
+	// Order by hardware
+	std::string mf1 = Utils::String::toUpper(sys1->getSystemMetadata().hardwareType);
+	std::string mf2 = Utils::String::toUpper(sys2->getSystemMetadata().hardwareType);
+	if (mf1 != mf2)
+		return mf1.compare(mf2) < 0;
+
+	// Then by name
+	std::string name1 = Utils::String::toUpper(sys1->getName());
+	std::string name2 = Utils::String::toUpper(sys2->getName());
+	return name1.compare(name2) < 0;
+}
+
 CollectionSystemManager* CollectionSystemManager::get()
 {
 	assert(sInstance);
@@ -213,6 +278,12 @@ void CollectionSystemManager::loadEnabledListFromSettings()
 // updates enabled system list in System View
 void CollectionSystemManager::updateSystemsList()
 {
+	auto sortMode = Settings::getInstance()->getString("SortSystems");
+	// isManufacturerSupported() seems to be used as a proxy for "is extra metadata available" even though it only checks for manufacturer
+	bool sortByManufacturer = SystemData::isManufacturerSupported() && sortMode == "manufacturer";
+	bool sortByHardware = SystemData::isManufacturerSupported() && sortMode == "hardware";
+	bool sortByReleaseDate = SystemData::isManufacturerSupported() && sortMode == "releaseDate";
+
 	// remove all Collection Systems
 	removeCollectionsFromDisplayedSystems();
 
@@ -222,26 +293,15 @@ void CollectionSystemManager::updateSystemsList()
 	// add custom enabled ones
 	addEnabledCollectionsToDisplayedSystems(&mCustomCollectionSystemsData, &map);
 
-	if (Settings::getInstance()->getBool("SortAllSystems"))
-	{
-		// sort custom individual systems with other systems
-		std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemSort);
-
-		// move RetroPie system to end, before auto collections
-		for(auto sysIt = SystemData::sSystemVector.cbegin(); sysIt != SystemData::sSystemVector.cend(); )
-		{
-			if ((*sysIt)->getName() == "retropie")
-			{
-				SystemData* retroPieSystem = (*sysIt);
-				sysIt = SystemData::sSystemVector.erase(sysIt);
-				SystemData::sSystemVector.push_back(retroPieSystem);
-				break;
-			}
-			else
-			{
-				sysIt++;
-			}
-		}
+	if (!sortMode.empty()) {
+		if (sortByManufacturer)
+			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemSortByManufacturer);
+		else if (sortByHardware)
+			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemSortByHardware);
+		else if (sortByReleaseDate)
+			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemSortByReleaseDate);
+		else if (sortMode == "alpha")
+			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemSortByAlpha);
 	}
 
 	if(mCustomCollectionsBundle->getRootFolder()->getChildren().size() > 0)

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -626,6 +626,20 @@ void SystemData::writeExampleConfig(const std::string& path)
 	LOG(LogError) << "Example config written!  Go read it at \"" << path << "\"!";
 }
 
+bool SystemData::isManufacturerSupported()
+{
+	for (auto sys : sSystemVector)
+	{
+		if (!sys->isGameSystem() || sys->isCollection())
+			continue;
+
+		if (!sys->getSystemMetadata().manufacturer.empty())
+			return true;
+	}
+
+	return false;
+}
+
 bool SystemData::hasDirtySystems()
 {
 	bool saveOnExit = !Settings::getInstance()->getBool("IgnoreGamelist") && Settings::getInstance()->getBool("SaveGamelistsOnExit");

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -22,8 +22,8 @@ using namespace Utils;
 
 std::vector<SystemData*> SystemData::sSystemVector;
 
-SystemData::SystemData(const std::string& name, const std::string& fullName, SystemEnvironmentData* envData, const std::string& themeFolder, bool CollectionSystem, bool groupedSystem) :
-	mName(name), mFullName(fullName), mEnvData(envData), mThemeFolder(themeFolder), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
+SystemData::SystemData(const SystemMetadata& metadata, SystemEnvironmentData* envData, bool CollectionSystem, bool groupedSystem) :
+	mMetadata(metadata), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
 {
 	mIsGroupSystem = groupedSystem;
 	mGameListHash = 0;
@@ -38,7 +38,7 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 	if(!CollectionSystem && !mIsGroupSystem)
 	{
 		mRootFolder = new FolderData(mEnvData->mStartPath, this);
-		mRootFolder->getMetadata().set("name", mFullName);
+		mRootFolder->getMetadata().set("name", getFullName());
 
 		std::unordered_map<std::string, FileData*> fileMap;
 		
@@ -49,13 +49,13 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 				return;
 		}
 
-		if (!Settings::getInstance()->getBool("IgnoreGamelist") && mName != "imageviewer")
+		if (!Settings::getInstance()->getBool("IgnoreGamelist") && getName() != "imageviewer")
 			parseGamelist(this, fileMap);
 	}
 	else
 	{
 		// virtual systems are updated afterwards, we're just creating the data structure
-		mRootFolder = new FolderData("" + name, this);
+		mRootFolder = new FolderData("" + getName(), this);
 	}
 	
 	auto defaultView = Settings::getInstance()->getString(getName() + ".defaultView");
@@ -105,7 +105,7 @@ void SystemData::setIsGameSystemStatus()
 	// we exclude non-game systems from specific operations (i.e. the "RetroPie" system, at least)
 	// if/when there are more in the future, maybe this can be a more complex method, with a proper list
 	// but for now a simple string comparison is more performant
-	mIsGameSystem = (mName != "retropie");
+	mIsGameSystem = (getName() != "retropie");
 }
 
 void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap)
@@ -245,13 +245,18 @@ std::vector<std::string> readList(const std::string& str, const char* delims = "
 SystemData* SystemData::loadSystem(pugi::xml_node system)
 {
 	std::vector<EmulatorData> emulatorList;
-
-	std::string name, fullname, path, cmd, themeFolder, defaultCore;
-
-	name = system.child("name").text().get();
-	fullname = system.child("fullname").text().get();
+	
+	std::string path, cmd, defaultCore;
 	path = system.child("path").text().get();
 	defaultCore = system.child("defaultCore").text().get();
+
+	SystemMetadata md;
+	md.name = system.child("name").text().get();
+	md.fullName = system.child("fullname").text().get();
+	md.manufacturer = system.child("manufacturer").text().get();
+	md.releaseYear = atoi(system.child("release").text().get());
+	md.hardwareType = system.child("hardware").text().get();
+	md.themeFolder = system.child("theme").text().as_string(md.name.c_str());
 
 	pugi::xml_node emulators = system.child("emulators");
 	if (emulators != NULL)
@@ -320,16 +325,13 @@ SystemData* SystemData::loadSystem(pugi::xml_node system)
 		if (platformId != PlatformIds::PLATFORM_UNKNOWN)
 			platformIds.push_back(platformId);
 		else if (str != NULL && str[0] != '\0' && platformId == PlatformIds::PLATFORM_UNKNOWN)
-			LOG(LogWarning) << "  Unknown platform for system \"" << name << "\" (platform \"" << str << "\" from list \"" << platformList << "\")";
+			LOG(LogWarning) << "  Unknown platform for system \"" << md.name << "\" (platform \"" << str << "\" from list \"" << platformList << "\")";
 	}
 
-	// theme folder
-	themeFolder = system.child("theme").text().as_string(name.c_str());
-
 	//validate
-	if (name.empty() || path.empty() || extensions.empty() || cmd.empty())
+	if (md.name.empty() || path.empty() || extensions.empty() || cmd.empty())
 	{
-		LOG(LogError) << "System \"" << name << "\" is missing name, path, extension, or command!";
+		LOG(LogError) << "System \"" << md.name << "\" is missing name, path, extension, or command!";
 		return nullptr;
 	}
 
@@ -346,7 +348,7 @@ SystemData* SystemData::loadSystem(pugi::xml_node system)
 
 	//create the system runtime environment data
 	SystemEnvironmentData* envData = new SystemEnvironmentData;
-	envData->mSystemName = name;
+	envData->mSystemName = md.name;
 	envData->mStartPath = path;
 	envData->mSearchExtensions = extensions;
 	envData->mLaunchCommand = cmd;
@@ -354,10 +356,10 @@ SystemData* SystemData::loadSystem(pugi::xml_node system)
 	envData->mEmulators = emulatorList;
 	envData->mGroup = system.child("group").text().get();
 
-	SystemData* newSys = new SystemData(name, fullname, envData, themeFolder);
+	SystemData* newSys = new SystemData(md, envData);
 	if (newSys->getRootFolder()->getChildren().size() == 0)
 	{
-		LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";
+		LOG(LogWarning) << "System \"" << md.name << "\" has no games! Ignoring it.";
 		delete newSys;
 
 		return nullptr;
@@ -388,7 +390,12 @@ void SystemData::createGroupedSystems()
 		envData->mStartPath = "";
 		envData->mLaunchCommand = "";
 
-		SystemData* system = new SystemData(item.first, item.first, envData, item.first, false, true);
+		SystemMetadata md;
+		md.name = item.first;
+		md.fullName = item.first;
+		md.themeFolder = item.first;
+
+		SystemData* system = new SystemData(md, envData, false, true);
 		system->mIsGroupSystem = true;
 		system->mIsGameSystem = false;
 
@@ -672,7 +679,7 @@ bool SystemData::isVisible()
 
 	if ((getDisplayedGameCount() > 0 ||
 		(UIModeController::getInstance()->isUIModeFull() && mIsCollectionSystem) ||
-		(mIsCollectionSystem && mName == "favorites")))
+		(mIsCollectionSystem && getName() == "favorites")))
 	{
 		if (!mIsCollectionSystem)
 		{
@@ -720,7 +727,7 @@ std::string SystemData::getGamelistPath(bool forWrite) const
 	if(Utils::FileSystem::exists(fileRomPath))
 		return fileRomPath;
 
-	std::string filePath = Utils::FileSystem::getHomePath() + "/.emulationstation/gamelists/" + mName + "/gamelist.xml";
+	std::string filePath = Utils::FileSystem::getHomePath() + "/.emulationstation/gamelists/" + mMetadata.name + "/gamelist.xml";
 
 	// Default to system rom folder
 	if (forWrite && !Utils::FileSystem::exists(filePath) && Utils::FileSystem::isDirectory(mRootFolder->getPath()))
@@ -732,7 +739,7 @@ std::string SystemData::getGamelistPath(bool forWrite) const
 	if (forWrite || Utils::FileSystem::exists(filePath))
 		return filePath;
 
-	return "/etc/emulationstation/gamelists/" + mName + "/gamelist.xml";
+	return "/etc/emulationstation/gamelists/" + mMetadata.name + "/gamelist.xml";
 }
 
 std::string SystemData::getThemePath() const
@@ -748,7 +755,7 @@ std::string SystemData::getThemePath() const
 		return localThemePath;
 
 	// not in game folder, try system theme in theme sets
-	localThemePath = ThemeData::getThemeFromCurrentSet(mThemeFolder);
+	localThemePath = ThemeData::getThemeFromCurrentSet(mMetadata.themeFolder);
 
 	if (Utils::FileSystem::exists(localThemePath))
 		return localThemePath;

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -126,6 +126,7 @@ public:
 	inline SystemEnvironmentData* getSystemEnvData() const { return mEnvData; }
 	inline const std::vector<PlatformIds::PlatformId>& getPlatformIds() const { return mEnvData->mPlatformIds; }
 	inline bool hasPlatformId(PlatformIds::PlatformId id) { if (!mEnvData) return false; return std::find(mEnvData->mPlatformIds.cbegin(), mEnvData->mPlatformIds.cend(), id) != mEnvData->mPlatformIds.cend(); }
+	inline const SystemMetadata& getSystemMetadata() const { return mMetadata; }
 
 	inline const std::shared_ptr<ThemeData>& getTheme() const { return mTheme; }
 
@@ -143,6 +144,7 @@ public:
 	int getDisplayedGameCount();
 	void updateDisplayedGameCount();
 
+	static bool isManufacturerSupported();
 	static bool hasDirtySystems();
 	static void deleteSystems();
 	static bool loadConfig(Window* window); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -28,6 +28,16 @@ struct EmulatorData
 	std::vector<std::string> mCores;
 };
 
+struct SystemMetadata
+{
+	std::string name;
+	std::string fullName;
+	std::string themeFolder;
+	std::string manufacturer;
+	int releaseYear;
+	std::string hardwareType;
+};
+
 struct SystemEnvironmentData
 {
 	std::string mSystemName;
@@ -102,17 +112,17 @@ struct SystemEnvironmentData
 class SystemData
 {
 public:
-	SystemData(const std::string& name, const std::string& fullName, SystemEnvironmentData* envData, const std::string& themeFolder, bool CollectionSystem = false, bool groupedSystem = false);
+	SystemData(const SystemMetadata& metadata, SystemEnvironmentData* envData, bool CollectionSystem = false, bool groupedSystem = false);
 	~SystemData();
 
 	static SystemData* getSystem(const std::string name);
 
 	inline FolderData* getRootFolder() const { return mRootFolder; };
-	inline const std::string& getName() const { return mName; }
-	inline const std::string& getFullName() const { return mFullName; }
+	inline const std::string& getName() const { return mMetadata.name; }
+	inline const std::string& getFullName() const { return mMetadata.fullName; }
 	inline const std::string& getStartPath() const { return mEnvData->mStartPath; }
 	//inline const std::vector<std::string>& getExtensions() const { return mEnvData->mSearchExtensions; }
-	inline const std::string& getThemeFolder() const { return mThemeFolder; }
+	inline const std::string& getThemeFolder() const { return mMetadata.themeFolder; }
 	inline SystemEnvironmentData* getSystemEnvData() const { return mEnvData; }
 	inline const std::vector<PlatformIds::PlatformId>& getPlatformIds() const { return mEnvData->mPlatformIds; }
 	inline bool hasPlatformId(PlatformIds::PlatformId id) { if (!mEnvData) return false; return std::find(mEnvData->mPlatformIds.cbegin(), mEnvData->mPlatformIds.cend(), id) != mEnvData->mPlatformIds.cend(); }
@@ -202,11 +212,9 @@ private:
 	bool mIsCollectionSystem;
 	bool mIsGameSystem;
 	bool mIsGroupSystem;
-	
-	std::string mName;
-	std::string mFullName;
+
+	SystemMetadata mMetadata;
 	SystemEnvironmentData* mEnvData;
-	std::string mThemeFolder;
 	std::shared_ptr<ThemeData> mTheme;
 
 	std::string mViewMode;

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -108,12 +108,27 @@ void GuiCollectionSystemsOptions::initializeMenu()
 			setVariable("reloadAll", true);
 	});
 
-	std::shared_ptr<SwitchComponent> sortAllSystemsSwitch = std::make_shared<SwitchComponent>(mWindow);
-	sortAllSystemsSwitch->setState(Settings::getInstance()->getBool("SortAllSystems"));
-	addWithLabel(_("SORT CUSTOM COLLECTIONS AND SYSTEMS"), sortAllSystemsSwitch);
-	addSaveFunc([this, sortAllSystemsSwitch]
+	// SORT COLLECTIONS AND SYSTEMS
+	std::string sortMode = Settings::getInstance()->getString("SortSystems");
+
+	auto sortType = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SORT COLLECTIONS AND SYSTEMS"), false);
+	sortType->add(_("NO"), "", sortMode.empty());
+	sortType->add(_("ALPHABETICALLY"), "alpha", sortMode == "alpha");
+
+	if (SystemData::isManufacturerSupported())
 	{
-		if (Settings::getInstance()->setBool("SortAllSystems", sortAllSystemsSwitch->getState()))
+		sortType->add(_("BY MANUFACTURER"), "manufacturer", sortMode == "manufacturer");
+		sortType->add(_("BY HARDWARE TYPE"), "hardware", sortMode == "hardware");
+		sortType->add(_("BY RELEASE YEAR"), "releaseDate", sortMode == "releaseDate");
+	}
+
+	if (!sortType->hasSelection())
+		sortType->selectFirstItem();
+	
+	addWithLabel(_("SORT SYSTEMS"), sortType);
+	addSaveFunc([this, sortType]
+	{
+		if (Settings::getInstance()->setString("SortSystems", sortType->getSelected()))
 			setVariable("reloadAll", true);
 	});
 

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -62,6 +62,7 @@ public:
 	void goToSystem(SystemData* system, bool animate);
 
 	bool input(InputConfig* config, Input input) override;
+	void showNavigationBar(const std::string& title, const std::function<std::string(SystemData* system)>& selector);
 	void update(int deltaTime) override;
 	void render(const Transform4x4f& parentTrans) override;
 

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -1,6 +1,7 @@
 #include "components/MenuComponent.h"
 
 #include "components/ButtonComponent.h"
+#include "components/MultiLineMenuEntry.h"
 
 #define BUTTON_GRID_VERT_PADDING  (Renderer::getScreenHeight()*0.0296296) //32
 #define BUTTON_GRID_HORIZ_PADDING (Renderer::getScreenWidth()*0.0052083333) //10
@@ -100,6 +101,45 @@ void MenuComponent::addWithLabel(const std::string& label, const std::shared_ptr
 
 	row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), theme->Text.font, theme->Text.color), true);
 	row.addElement(comp, false, invert_when_selected);
+	addRow(row, setCursorHere);
+}
+
+void MenuComponent::addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool invert_when_selected, bool multiLine)
+{
+	auto theme = ThemeData::getMenuTheme();
+
+	ComponentListRow row;
+
+	if (!iconName.empty())
+	{
+		std::string iconPath = theme->getMenuIcon(iconName);
+		if (!iconPath.empty())
+		{
+			// icon
+			auto icon = std::make_shared<ImageComponent>(mWindow, true);
+			icon->setImage(iconPath);
+			icon->setColorShift(theme->Text.color);
+			icon->setResize(0, theme->Text.font->getLetterHeight() * 1.25f);
+			row.addElement(icon, false);
+
+			// spacer between icon and text
+			auto spacer = std::make_shared<GuiComponent>(mWindow);
+			spacer->setSize(10, 0);
+			row.addElement(spacer, false);
+		}
+	}
+
+	if (!description.empty())
+		row.addElement(std::make_shared<MultiLineMenuEntry>(mWindow, Utils::String::toUpper(label), description, multiLine), true);
+	else	
+		row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), theme->Text.font, theme->Text.color), true);
+
+	if (comp != nullptr)
+		row.addElement(comp, false, invert_when_selected);
+
+	if (func != nullptr)
+		row.makeAcceptInputHandler(func);
+
 	addRow(row, setCursorHere);
 }
 

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -31,6 +31,7 @@ public:
 	inline void addRow(const ComponentListRow& row, bool setCursorHere = false) { mList->addRow(row, setCursorHere); updateSize(); }
 
 	void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true);
+	void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true, bool multiLine = false);
 	void addEntry(const std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName="", bool setCursorHere = false, bool invert_when_selected = true);
 	void addGroup(const std::string& label) { mList->addGroup(label); updateSize(); }
 

--- a/es-core/src/components/MultiLineMenuEntry.h
+++ b/es-core/src/components/MultiLineMenuEntry.h
@@ -11,7 +11,7 @@
 class MultiLineMenuEntry : public ComponentGrid
 {
 public:
-	MultiLineMenuEntry(Window* window, const std::string& text, const std::string& substring) :
+	MultiLineMenuEntry(Window* window, const std::string& text, const std::string& substring, bool multiLine = false) :
 		ComponentGrid(window, Vector2i(1, 2))
 	{
 		auto theme = ThemeData::getMenuTheme();

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -615,6 +615,22 @@ namespace Utils
 
 			return output;
 		}
+
+		std::string join(const std::vector<std::string>& items, std::string separator)
+		{
+			std::string data;
+
+			for (auto line : items)
+			{
+				if (!data.empty())
+					data += separator;
+
+				data += line;
+			}
+
+			return data;
+		}
+
 		const std::string boolToString(bool value, bool uppercase)
 		{
 			if (uppercase)

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -29,6 +29,7 @@ namespace Utils
 		std::string  scramble           (const std::string& _input, const std::string& key);
 		std::vector<std::string> split	(const std::string& s, char seperator);	
 		std::vector<std::string> splitAny(const std::string& s, const std::string& seperator);
+		std::string join(const std::vector<std::string>& items, std::string separator);
         int			compareIgnoreCase(const std::string& name1, const std::string& name2);
 		const std::string boolToString(bool value, bool uppercase = false);
 


### PR DESCRIPTION
This adds the quick "go to" system menu from the JELOS version of EmulationStation. The majority of this code was migrated from there but some was hand-written to more closely match this fork and avoid further dependencies.

I've split this into 3 commits which are hopefully easier to review than the entire change:
1. Migrates fields from `SystemData` into a `SystemMetadata` struct, adding extra fields (manufacturer, release year, hardware type) that will be parsed from `es_systems.cfg` if present.
2. Replaces the single "SortAllSystems" bool setting with a "SortSystems" string, allowing the system list to be sorted in different ways.
3. Adds the new "Go to [SortMode]" menu, accessed by pressing B at the system menu.

The default behaviour should be no different than before; "SortAllSystems" defaulted to off, and the new "SortSystems" will default to no sorting. If no sorting is applied then the "Go to" menu is disabled.

This whole feature really depends on having more data in `es_systems.cfg` (which isn't in this repo) to fill in the manufacturer/year/hardware type for all systems. It won't _break_ if that data is missing, but the sort options won't do anything if the data isn't there. I've added all this into the most recent version from the arkos repo (txt extension added to attach to Github): 
[es_systems.cfg.txt](https://github.com/christianhaitian/EmulationStation-fcamod/files/13369902/es_systems.cfg.txt)

Demo video: https://www.youtube.com/watch?v=e2Y4qqfusrQ