### PR TITLE
missed translations when system sort activation

### DIFF
--- a/resources/locale/ko/emulationstation2.po
+++ b/resources/locale/ko/emulationstation2.po
@@ -1261,6 +1261,15 @@ msgstr "시스템 정렬"
 msgid "ALPHABETICALLY"
 msgstr "사전(알파벳) 순"
 
+msgid "BY MANUFACTURER"
+msgstr "제조사 순"
+
+msgid "BY HARDWARE TYPE"
+msgstr "하드웨어 순"
+
+msgid "BY RELEASE YEAR"
+msgstr "출시 년도 순"
+
 msgid "IMAGE SOURCE"
 msgstr "이미지 출처"
 


### PR DESCRIPTION
 at SORT CUSTOM COLLECTIONS AND SYSTEMS
missed translations added
This menu item appears only when all system metadata in es_systems.cfg has been filled in.