### PR TITLE
[PopupKeyboard] Add Korean & 4th Layout & Unicode support for "JUMP TO..."

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -35,7 +35,7 @@ private:
 
 	MenuComponent mMenu;
 
-	typedef OptionListComponent<char> LetterList;
+	typedef OptionListComponent<std::string> LetterList;
 	std::shared_ptr<LetterList> mJumpToLetterList;
 
 	typedef OptionListComponent<unsigned int> SortList;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -612,7 +612,10 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)
 
 			SystemData* system = it->first;
 		
+			std::string cursorPath;
 			FileData* cursor = view->getCursor();
+			if (cursor != nullptr && !cursor->isPlaceHolder())
+				cursorPath = cursor->getPath();
 
 			mGameListViews.erase(it);
 
@@ -624,9 +627,21 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)
 
 			std::shared_ptr<IGameListView> newView = getGameListView(system);
 			
-			// to counter having come from a placeholder
-			if (cursor != nullptr && !cursor->isPlaceHolder() && system->getName() != "recent")
-				newView->setCursor(cursor);
+			if (!cursorPath.empty())
+			{
+				ISimpleGameListView* view = dynamic_cast<ISimpleGameListView*>(newView.get());
+				if (view != nullptr)
+				{
+					for (auto file : view->getFileDataEntries())
+					{
+						if (file->getPath() == cursorPath)
+						{
+							newView->setCursor(file);
+							break;
+						}
+					}
+				}
+			}
 			
             Vector3f position = view->getPosition();
 

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -28,13 +28,12 @@ public:
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
+	virtual std::vector<FileData*> getFileDataEntries() override;
 
 	virtual void	setThemeName(std::string name);
 	virtual void onShow() override;
 
 protected:
-	virtual std::vector<FileData*> getFileDataEntries() override;
-
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -38,9 +38,9 @@ public:
 
 	virtual void setThemeName(std::string name);	
 	virtual void onShow();
+	virtual std::vector<FileData*> getFileDataEntries() override;
 
 protected:
-	virtual std::vector<FileData*> getFileDataEntries() override;
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -45,6 +45,7 @@ public:
 	virtual void setThemeName(std::string name);
 
 	virtual std::vector<std::string> getEntriesLetters() = 0;
+	virtual std::vector<FileData*> getFileDataEntries() = 0;
 
 protected:
 	std::string mCustomThemeName;

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -202,20 +202,128 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 	return IGameListView::input(config, input);
 }
 
+bool ISimpleGameListView::moveToLetter(const std::string& letter)
+{
+	auto files = getFileDataEntries();
+	long letterIndex = -1;
+
+	for (int i = files.size() - 1; i >= 0; i--)
+	{
+		const std::string& name = files.at(i)->getName();
+		if (name.empty())
+			continue;
+
+		std::string checkLetter;
+
+		if (Utils::String::isKorean(name.c_str()))
+		{
+			const char* koreanLetter = nullptr;
+
+			std::string nameChar = name.substr(0, 3);
+			if (!Utils::String::splitHangulSyllable(nameChar.c_str(), &koreanLetter) || !koreanLetter)
+				continue; // Korean supports chosung search only.
+			else
+				checkLetter = std::string(koreanLetter, 3);
+		}
+		else
+		{
+			checkLetter = std::string(1, toupper(name[0]));
+		}
+
+		if (letterIndex >= 0 && checkLetter != letter)
+			break;
+
+		if (checkLetter == letter)
+			letterIndex = i;
+	}
+
+	if (letterIndex >= 0) {
+		setCursor(files.at(letterIndex));
+		return true;
+	}
+
+	return false;
+}
+
+void ISimpleGameListView::moveToLetterByOffset(int offset)
+{
+	std::vector<std::string> letters = getEntriesLetters();
+	if (letters.empty())
+		return;
+
+	FileData* game = getCursor();
+	if (game == nullptr)
+		return;
+
+	const std::string& namecurrent = game->getName();
+	std::string curLetter;
+
+	if (Utils::String::isKorean(namecurrent.c_str()))
+	{
+		const char* koreanLetter = nullptr;
+
+		std::string nameChar = namecurrent.substr(0, 3);
+		if (!Utils::String::splitHangulSyllable(nameChar.c_str(), &koreanLetter) || !koreanLetter)
+			curLetter = std::string(letters.at(0)); // Korean supports chosung search only. set default.
+		else
+			curLetter = std::string(koreanLetter, 3);
+	}
+	else
+	{
+		curLetter = std::string(1, toupper(namecurrent[0]));
+	}
+
+	auto it = std::find(letters.begin(), letters.end(), curLetter);
+	if (it != letters.end())
+	{
+		int index = std::distance(letters.begin(), it) + offset;
+		if (index < 0)
+			index = letters.size() - 1;
+		else if (index >= letters.size())
+			index = 0;
+
+		moveToLetter(letters.at(index));
+	}
+}
+
+void ISimpleGameListView::moveToNextLetter()
+{
+	moveToLetterByOffset(1);
+}
+
+void ISimpleGameListView::moveToPreviousLetter()
+{
+	moveToLetterByOffset(-1);
+}
+
 std::vector<std::string> ISimpleGameListView::getEntriesLetters()
 {
 	std::set<std::string> setOfLetters;
 
 	for (auto file : getFileDataEntries())
-		if (file->getType() == GAME)
-			setOfLetters.insert(std::string(1, toupper(file->getName()[0])));
+	{
+		if (file->getType() != GAME)
+			continue;
 
-	std::vector<std::string> letters;
+		const std::string& name = file->getName();
 
-	for (const auto letter : setOfLetters)
-		letters.push_back(letter);
+		if (Utils::String::isKorean(name.c_str()))
+		{
+			const char* koreanLetter = nullptr;
 
-	std::sort(letters.begin(), letters.end());
+			std::string nameChar = name.substr(0, 3);
+			if (!Utils::String::splitHangulSyllable(nameChar.c_str(), &koreanLetter) || !koreanLetter)
+				continue;
+
+			setOfLetters.insert(std::string(koreanLetter, 3));
+		}
+		else
+		{
+			setOfLetters.insert(std::string(1, toupper(name[0])));
+		}
+	}
+
+	std::vector<std::string> letters(setOfLetters.begin(), setOfLetters.end());
 	return letters;
 }
 

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -28,9 +28,14 @@ public:
 	virtual void launch(FileData* game) = 0;
 
 	virtual std::vector<std::string> getEntriesLetters() override;
+	// virtual std::vector<FileData*> getFileDataEntries() = 0;
+
+	virtual bool moveToLetter(const std::string& letter);
+	virtual void moveToLetterByOffset(int offset);
+	virtual void moveToNextLetter();
+	virtual void moveToPreviousLetter();
 
 protected:
-	virtual std::vector<FileData*> getFileDataEntries() = 0;
 
 	virtual std::string getQuickSystemSelectRightButton() = 0;
 	virtual std::string getQuickSystemSelectLeftButton() = 0;

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -72,9 +72,15 @@ void TextEditComponent::textInput(const char* text)
 				mCursor = (unsigned int)newCursor;
 			}
 		}
-		else {
+		else if (mCursor > 2 && Utils::String::isKorean(text) && Utils::String::isKorean(mText.substr(mCursor - 3, 3).c_str()))
+		{
+			Utils::String::koreanTextInput(text, mText, mCursor);
+		}
+		else
+		{
 			mText.insert(mCursor, text);
-			mCursor += (unsigned int)strlen(text);
+			size_t newCursor = Utils::String::nextCursor(mText, mCursor);
+			mCursor = (unsigned int)newCursor;
 		}
 	}
 

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "EsLocale.h"
 #include "SystemConf.h"
+#include "Settings.h"
 
 #define OSK_WIDTH (Renderer::isSmallScreen() ? Renderer::getScreenWidth() : Renderer::getScreenWidth() * 0.78f)
 #define OSK_HEIGHT (Renderer::isSmallScreen() ? Renderer::getScreenHeight() : Renderer::getScreenHeight() * 0.60f)
@@ -12,25 +13,31 @@
 #define OSK_PADDINGY (Renderer::getScreenWidth() * 0.01f)
 
 #define BUTTON_GRID_HORIZ_PADDING (Renderer::getScreenWidth()*0.0052083333)
+#define BUTTON_LAYER_SIZE (4)
 
 std::vector<std::vector<const char*>> kbUs {
 
 	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+", "DEL" },
 	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "=", "DEL" },
 	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+", "DEL" },
+	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "=", "DEL" },
 
 	{ "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "{", "}", "OK" },
 	{ "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "[", "]", "OK" },
+	{ "à", "ä", "è", "ë", "ì", "ï", "ò", "ö", "ù", "ü", "¨", "¿", "OK" },
 	{ "à", "ä", "è", "ë", "ì", "ï", "ò", "ö", "ù", "ü", "¨", "¿", "OK" },
 
 	{ "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "\"", "|", "-rowspan-" },
 	{ "A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "'", "\\", "-rowspan-" },
 	{ "á", "â", "é", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "-rowspan-" },
+	{ "á", "â", "é", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "-rowspan-" },
 
 	{ "~", "z", "x", "c", "v", "b", "n", "m", ",", ".", "?", "ALT", "-colspan-" },
 	{ "`", "Z", "X", "C", "V", "B", "N", "M", "<", ">", "/", "ALT", "-colspan-" },
 	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
+	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
 
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" }
@@ -40,24 +47,55 @@ std::vector<std::vector<const char*>> kbFr {
 	{ "&", "é", "\"", "'", "(", "#", "è", "!", "ç", "à", ")", "-", "DEL" },
 	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_", "DEL" },
 	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_", "DEL" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_", "DEL" },
 	
 	{ "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", "OK" },
 	{ "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P", "¨", "*", "OK" },
+	{ "à", "ä", "ë", "ì", "ï", "ò", "ö", "ü", "\\", "|", "§", "°", "OK" },
 	{ "à", "ä", "ë", "ì", "ï", "ò", "ö", "ü", "\\", "|", "§", "°", "OK" },
 
 	{ "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "`", "-rowspan-" },
 	{ "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M", "%", "£", "-rowspan-" },
 	{ "á", "â", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "¿", "-rowspan-" },
+	{ "á", "â", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "¿", "-rowspan-" },
 
 	{ "<", "w", "x", "c", "v", "b", "n", ",", ";", ":", "=", "ALT", "-colspan-" },
 	{ ">", "W", "X", "C", "V", "B", "N", "?", ".", "/", "+", "ALT", "-colspan-" },
 	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
+	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
 
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
 	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" }
 };
 
+std::vector<std::vector<const char*>> kbKr{
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "DEL" },
+	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "DEL" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "DEL" },
+	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "DEL" },
+
+	{ "ㅂ", "ㅈ", "ㄷ", "ㄱ", "ㅅ", "ㅛ", "ㅕ", "ㅑ", "ㅐ", "ㅔ", "[", "]", "OK" },
+	{ "ㅃ", "ㅉ", "ㄸ", "ㄲ", "ㅆ", "ㅛ", "ㅕ", "ㅑ", "ㅒ", "ㅖ", "{", "}", "OK" },
+	{ "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "OK" },
+	{ "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "{", "}", "OK" },
+
+	{ "ㅁ", "ㄴ", "ㅇ", "ㄹ", "ㅎ", "ㅗ", "ㅓ", "ㅏ", "ㅣ", ";", "'", "\\", "-rowspan-" },
+	{ "ㅁ", "ㄴ", "ㅇ", "ㄹ", "ㅎ", "ㅗ", "ㅓ", "ㅏ", "ㅣ", ":", "\"", "|", "-rowspan-" },
+	{ "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "\\", "-rowspan-" },
+	{ "A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "\"", "|", "-rowspan-" },
+
+	{ "ㅋ", "ㅌ", "ㅊ", "ㅍ", "ㅠ", "ㅜ", "ㅡ", ",", ".", "/", "`", "ALT", "-colspan-" },
+	{ "ㅋ", "ㅌ", "ㅊ", "ㅍ", "ㅠ", "ㅜ", "ㅡ", "<", ">", "?", "~", "ALT", "-colspan-" },
+	{ "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "`", "ALT", "-colspan-" },
+	{ "Z", "X", "C", "V", "B", "N", "M", "<", ">", "?", "~", "ALT", "-colspan-" },
+
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" }
+};
 
 GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::string& title, const std::string& initValue,
 	const std::function<void(const std::string&)>& okCallback, bool multiLine, const std::string acceptBtnText)
@@ -78,7 +116,7 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 
 	mTitle = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(title), theme->Title.font, theme->Title.color, ALIGN_CENTER);
 	
-	mKeyboardGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(kbUs[0].size(), kbUs.size() / 3));
+	mKeyboardGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(kbUs[0].size(), kbUs.size() / BUTTON_LAYER_SIZE));
 
 	mText = std::make_shared<TextEditComponent>(mWindow);
 	mText->setValue(initValue);
@@ -100,28 +138,24 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 	{
 		std::vector<std::vector<const char*>>* layout = &kbUs;
 
-		std::string language = SystemConf::getInstance()->get("system.language");
-		if (!language.empty())
-		{
-			auto shortNameDivider = language.find("_");
-			if (shortNameDivider != std::string::npos)
-				language = Utils::String::toLower(language.substr(0, shortNameDivider));
-		}
-
+		std::string language = Settings::getInstance()->getString("Language");
 		if (language == "fr")
 			layout = &kbFr;
+		else if (language == "ko")
+			layout = &kbKr;
 
-		for (unsigned int i = 0; i < layout->size() / 3; i++)
+		for (unsigned int i = 0; i < layout->size() / BUTTON_LAYER_SIZE; i++)
 		{			
 			std::vector<std::shared_ptr<ButtonComponent>> buttons;
 			for (unsigned int j = 0; j < (*layout)[i].size(); j++)
 			{
-				std::string lower = (*layout)[3 * i][j];
+				std::string lower = (*layout)[BUTTON_LAYER_SIZE * i][j];
 				if (lower.empty() || lower == "-rowspan-" || lower == "-colspan-")
 					continue;
 
-				std::string upper = (*layout)[3 * i + 1][j];
-				std::string alted = (*layout)[3 * i + 2][j];
+				std::string upper = (*layout)[BUTTON_LAYER_SIZE * i + 1][j];
+				std::string lowerAlted = (*layout)[BUTTON_LAYER_SIZE * i + 2][j];
+				std::string upperAlted = (*layout)[BUTTON_LAYER_SIZE * i + 3][j];
 
 				std::shared_ptr<ButtonComponent> button = nullptr;
 
@@ -129,19 +163,22 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 				{
 					lower = _U("\u232B");
 					upper = _U("\u232B");
-					alted = _U("\u232B");
+					lowerAlted = _U("\u232B");
+					upperAlted = _U("\u232B");
 				}
 				else if (lower == "OK")
 				{
 					lower = _U("\u23CE");
 					upper = _U("\u23CE");
-					alted = _U("\u23CE");
+					lowerAlted = _U("\u23CE");
+					upperAlted = _U("\u23CE");
 				}
 				else if (lower != "SHIFT" && lower.length() > 1)
 				{
 					lower = _(lower.c_str());
 					upper = _(upper.c_str());
-					alted = _(alted.c_str());
+					lowerAlted = _(lowerAlted.c_str());
+					upperAlted = _(upperAlted.c_str());
 				}
 
 				if (lower == "SHIFT")
@@ -156,7 +193,7 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 					button = mAltButton;
 				}
 				else
-					button = makeButton(lower, upper, alted);
+					button = makeButton(lower, upper, lowerAlted, upperAlted);
 
 				button->setPadding(Vector4f(BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f));
 				button->setRenderNonFocusedBackground(false);
@@ -165,14 +202,14 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 				int colSpan = 1;
 				for (unsigned int cs = j + 1; cs < (*layout)[i].size(); cs++)
 				{
-					if (std::string((*layout)[3 * i][cs]) == "-colspan-")
+					if (std::string((*layout)[BUTTON_LAYER_SIZE * i][cs]) == "-colspan-")
 						colSpan++;
 					else
 						break;
 				}
 				
 				int rowSpan = 1;
-				for (unsigned int cs = (3 * i) + 3; cs < layout->size(); cs += 3)
+				for (unsigned int cs = (BUTTON_LAYER_SIZE * i) + BUTTON_LAYER_SIZE; cs < layout->size(); cs += BUTTON_LAYER_SIZE)
 				{
 					if (std::string((*layout)[cs][j]) == "-rowspan-")
 						rowSpan++;
@@ -356,59 +393,50 @@ bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
 	return false;
 }
 
-// Shifts the keys when user hits the shift button.
-void GuiTextEditPopupKeyboard::shiftKeys() 
+void GuiTextEditPopupKeyboard::toggleKeyState(bool& state, std::shared_ptr<ButtonComponent>& button)
 {
-	if (mAlt && !mShift)
-		altKeys();
+	state = !state;
 
-	mShift = !mShift;
-
-	if (mShift)
+	if (state)
 	{
-		mShiftButton->setRenderNonFocusedBackground(true);
-		mShiftButton->setColorShift(0xFF0000FF);
+		button->setRenderNonFocusedBackground(true);
+		button->setColorShift(0xFF0000FF);
 	}
 	else
 	{
-		mShiftButton->setRenderNonFocusedBackground(false);
-		mShiftButton->removeColorShift();
+		button->setRenderNonFocusedBackground(false);
+		button->removeColorShift();
 	}
 
-	for (auto & kb : keyboardButtons)
+	updateKeyboardButtons();
+}
+
+void GuiTextEditPopupKeyboard::updateKeyboardButtons()
+{
+	for (auto& kb : keyboardButtons)
 	{
-		const std::string& text = mShift ? kb.shiftedKey : kb.key;
+		const std::string& text = (mAlt && mShift) ? kb.altedShiftedKey
+			: (mAlt) ? kb.altedKey
+			: (mShift) ? kb.shiftedKey
+			: kb.key;
+
 		auto sz = kb.button->getSize();
 		kb.button->setText(text, text, false);
 		kb.button->setSize(sz);
 	}
 }
 
+void GuiTextEditPopupKeyboard::shiftKeys()
+{
+	toggleKeyState(mShift, mShiftButton);
+}
+
 void GuiTextEditPopupKeyboard::altKeys()
 {
-	if (mShift && !mAlt)
-		shiftKeys();
+	if (mShift)
+		toggleKeyState(mShift, mShiftButton);
 
-	mAlt = !mAlt;
-
-	if (mAlt)
-	{
-		mAltButton->setRenderNonFocusedBackground(true);
-		mAltButton->setColorShift(0xFF0000FF);
-	}
-	else
-	{
-		mAltButton->setRenderNonFocusedBackground(false);
-		mAltButton->removeColorShift();
-	}
-
-	for (auto & kb : keyboardButtons)
-	{
-		const std::string& text = mAlt ? kb.altedKey : kb.key;
-		auto sz = kb.button->getSize();
-		kb.button->setText(text, text, false);
-		kb.button->setSize(sz);
-	}
+	toggleKeyState(mAlt, mAltButton);
 }
 
 std::vector<HelpPrompt> GuiTextEditPopupKeyboard::getHelpPrompts()
@@ -426,9 +454,9 @@ std::vector<HelpPrompt> GuiTextEditPopupKeyboard::getHelpPrompts()
 	return prompts;
 }
 
-std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey)
+std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey, const std::string& altedShiftedKey)
 {
-	std::shared_ptr<ButtonComponent> button = std::make_shared<ButtonComponent>(mWindow, key, key, [this, key, shiftedKey, altedKey]
+	std::shared_ptr<ButtonComponent> button = std::make_shared<ButtonComponent>(mWindow, key, key, [this, key, shiftedKey, altedKey, altedShiftedKey]
 	{
 		if (key == _U("\u23CE") || key.find("OK") != std::string::npos)
 		{
@@ -459,22 +487,34 @@ std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std:
 			return;
 		}
 
-		if (mAlt && altedKey.empty())
-			return;
+		if (mAlt)
+		{
+			if (mShift && altedShiftedKey.empty())
+				return;
+			if (altedKey.empty())
+				return;
+		}
 
 		mText->startEditing();
 
-		if (mAlt)
-			mText->textInput(altedKey.c_str());
+		const char* text;
+		if (mAlt && mShift)
+			text = altedShiftedKey.c_str();
+		else if (mAlt)
+			text = altedKey.c_str();
 		else if (mShift)
-			mText->textInput(shiftedKey.c_str());
+			text = shiftedKey.c_str();
 		else
-			mText->textInput(key.c_str());
+			text = key.c_str();
+		mText->textInput(text);
 
 		mText->stopEditing();
+
+		if (Utils::String::isKorean(text) && mShift)
+			shiftKeys();
 	}, false);
 	
-	KeyboardButton kb(button, key, shiftedKey, altedKey);
+	KeyboardButton kb(button, key, shiftedKey, altedKey, altedShiftedKey);
 	keyboardButtons.push_back(kb);
 	return button;
 }

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.h
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.h
@@ -26,15 +26,18 @@ private:
 		const std::string key;
 		const std::string shiftedKey;
 		const std::string altedKey;
-		KeyboardButton(const std::shared_ptr<ButtonComponent> b, const std::string& k, const std::string& sk, const std::string& ak) : button(b), key(k), shiftedKey(sk), altedKey(ak) {};
+		const std::string altedShiftedKey;
+		KeyboardButton(const std::shared_ptr<ButtonComponent> b, const std::string& k, const std::string& sk, const std::string& ak, const std::string& ask) : button(b), key(k), shiftedKey(sk), altedKey(ak), altedShiftedKey(ask) {};
 	};
 	
-	std::shared_ptr<ButtonComponent> makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey);
+	std::shared_ptr<ButtonComponent> makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey, const std::string& altedShiftedKey);
 	std::vector<KeyboardButton> keyboardButtons;
 	
 	std::shared_ptr<ButtonComponent> mShiftButton;	
 	std::shared_ptr<ButtonComponent> mAltButton;
 
+	void toggleKeyState(bool& state, std::shared_ptr<ButtonComponent>& button);
+	void updateKeyboardButtons();
 	void shiftKeys();
 	void altKeys();
 

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -636,6 +636,279 @@ namespace Utils
 				(uni >= 0xAC00 && uni <= 0xD7A3);       // Unicode range for Hangul syllables (가 to 힣)
 		}
 
+		bool isKorean(const char* _string, bool checkFirstChar)
+		{
+			if (!_string)
+				return false;
+
+			size_t len = strlen(_string);
+			if (len < 3)
+				return false;
+
+			const char* target = _string;
+			if (!checkFirstChar)
+			{
+				const char* ptr = _string + len - 1;
+				while (ptr > _string && (*ptr & 0xC0) == 0x80)
+					ptr--;
+
+				target = ptr;
+			}
+
+			size_t cursor = 0;
+			unsigned int uni = chars2Unicode(std::string(target, 3), cursor);
+
+			return isKorean(uni);
+		} // isKorean
+
+		KoreanCharType getKoreanCharType(const char* _string)
+		{
+			if (!_string || strlen(_string) != 3)
+				return KoreanCharType::NONE;
+
+			size_t cursor = 0;
+			unsigned int uni = chars2Unicode(std::string(_string), cursor);
+
+			if (uni >= 0x3131 && uni <= 0x314E)
+				return KoreanCharType::JAEUM;
+
+			if (uni >= 0x314F && uni <= 0x3163)
+				return KoreanCharType::MOEUM;
+
+			return KoreanCharType::NONE;
+
+		} // getKoreanCharType
+
+		bool splitHangulSyllable(const char* input, const char** chosung, const char** joongsung, const char** jongsung)
+		{
+			if (!input)
+				return false;
+
+			size_t len = strlen(input);
+			if (len < 3)
+				return false;
+
+			switch (getKoreanCharType(input))
+			{
+			case KoreanCharType::JAEUM:
+				*chosung = input;
+				break;
+			case KoreanCharType::MOEUM:
+				if (joongsung) *joongsung = input;
+				break;
+			default:
+				size_t cursor = 0;
+				unsigned int unicode = chars2Unicode(input, cursor) - 0xAC00;
+
+				int chosungIdx = unicode / (28 * 21);
+				int joongsungIdx = (unicode / 28) % 21;
+				int jongsungIdx = unicode % 28;
+
+				*chosung = KOREAN_CHOSUNG_LIST.at(chosungIdx);
+				if (joongsung) *joongsung = KOREAN_JOONGSUNG_LIST.at(joongsungIdx);
+				if (jongsung) *jongsung = KOREAN_JONGSUNG_LIST.at(jongsungIdx);
+				break;
+			}
+
+			return true;
+		}
+
+		void koreanTextInput(const char* text, std::string& componentText, unsigned int& componentCursor)
+		{
+			if (!text)
+				return;
+
+			if (strlen(text) != 3)
+				return;
+
+			if (componentText.size() < 3)
+				return;
+
+			KoreanCharType charType = getKoreanCharType(text);
+
+			std::string lastCharString = componentText.substr(componentCursor - 3, 3);
+			const char* lastChar = lastCharString.c_str();
+
+			const char* chosung = "";
+			const char* joongsung = "";
+			const char* jongsung = "";
+			splitHangulSyllable(lastChar, &chosung, &joongsung, &jongsung);
+
+			auto eraseAndInsert = [&](const std::string& toInsert, bool moveCursorLeft = true)
+				{
+					size_t cursor = prevCursor(componentText, componentCursor);
+					componentText.erase(componentText.begin() + cursor, componentText.begin() + componentCursor);
+					componentText.insert(cursor, toInsert);
+					if (moveCursorLeft)
+						componentCursor -= 3;
+				};
+
+			auto makeHangul = [&](int chosungIdx, int joongsungIdx, int jongsungIdx) -> std::string
+				{
+					unsigned int code = ((chosungIdx * 21) + joongsungIdx) * 28 + jongsungIdx + 0xAC00;
+					return unicode2Chars(code);
+				};
+
+			auto findIndex = [&](const std::vector<const char*>& vec, const char* key) -> int
+				{
+					auto it = std::find_if(vec.begin(), vec.end(), [&](const char* item)
+						{
+							return std::strcmp(item, key) == 0;
+						});
+
+					return (it != vec.end()) ? std::distance(vec.begin(), it) : -1;
+				};
+
+			if (!strcmp(lastChar, chosung) && charType == KoreanCharType::JAEUM)
+			{
+				std::string combine = std::string(chosung) + text;
+
+				int idx = findIndex(KOREAN_GYEOP_BATCHIM_COMBINATIONS, combine.c_str());
+				if (idx != -1)
+					eraseAndInsert(KOREAN_GYEOP_BATCHIM_LIST.at(idx));
+				else
+					componentText.insert(componentCursor, text);
+			}
+			else if (!strcmp(lastChar, chosung) && charType == KoreanCharType::MOEUM)
+			{
+				int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, text);
+
+				int gyeopBatchimIdx = findIndex(KOREAN_GYEOP_BATCHIM_LIST, lastChar);
+				if (gyeopBatchimIdx != -1)
+				{
+					char jaeum1[4] = {};
+					strncpy(jaeum1, KOREAN_GYEOP_BATCHIM_COMBINATIONS.at(gyeopBatchimIdx), 3);
+					jaeum1[3] = '\0';
+
+					char jaeum2[4] = {};
+					strncpy(jaeum2, KOREAN_GYEOP_BATCHIM_COMBINATIONS.at(gyeopBatchimIdx) + 3, 3);
+					jaeum2[3] = '\0';
+
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, static_cast<const char*>(jaeum2));
+					std::string hangul = std::string(jaeum1) + makeHangul(chosungIdx, joongsungIdx, 0);
+
+					eraseAndInsert(hangul, false);
+				}
+				else
+				{
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, lastChar);
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, 0);
+
+					eraseAndInsert(hangul);
+				}
+			}
+			else if (!strcmp(lastChar, joongsung) && charType == KoreanCharType::JAEUM)
+			{
+				componentText.insert(componentCursor, text);
+			}
+			else if (!strcmp(lastChar, joongsung) && charType == KoreanCharType::MOEUM)
+			{
+				std::string combine = std::string(lastChar) + text;
+
+				int idx = findIndex(KOREAN_IJUNG_MOEUM_COMBINATIONS, combine.c_str());
+				if (idx != -1)
+					eraseAndInsert(KOREAN_IJUNG_MOEUM_LIST.at(idx));
+				else
+					componentText.insert(componentCursor, text);
+			}
+			else if (strcmp(jongsung, " ") && charType == KoreanCharType::JAEUM)
+			{
+				std::string combine = std::string(jongsung) + text;
+
+				int idx = findIndex(KOREAN_GYEOP_BATCHIM_COMBINATIONS, combine.c_str());
+
+				if (idx != -1)
+				{
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, chosung);
+					int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, joongsung);
+					int jongsungIdx = findIndex(KOREAN_JONGSUNG_LIST, KOREAN_GYEOP_BATCHIM_LIST.at(idx));
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, jongsungIdx);
+
+					eraseAndInsert(hangul);
+				}
+				else
+				{
+					componentText.insert(componentCursor, text);
+				}
+			}
+			else if (strcmp(jongsung, " ") && charType == KoreanCharType::MOEUM)
+			{
+				int idx = findIndex(KOREAN_GYEOP_BATCHIM_LIST, jongsung);
+				if (idx != -1)
+				{
+					char jaeum1[4] = {};
+					strncpy(jaeum1, KOREAN_GYEOP_BATCHIM_COMBINATIONS.at(idx), 3);
+					jaeum1[3] = '\0';
+
+					char jaeum2[4] = {};
+					strncpy(jaeum2, KOREAN_GYEOP_BATCHIM_COMBINATIONS.at(idx) + 3, 3);
+					jaeum2[3] = '\0';
+
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, chosung);
+					int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, joongsung);
+					int jongsungIdx = findIndex(KOREAN_JONGSUNG_LIST, static_cast<const char*>(jaeum1));
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, jongsungIdx);
+
+					chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, static_cast<const char*>(jaeum2));
+					joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, text);
+					hangul += makeHangul(chosungIdx, joongsungIdx, 0);
+
+					eraseAndInsert(hangul, false);
+				}
+				else
+				{
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, chosung);
+					int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, joongsung);
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, 0);
+
+					chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, jongsung);
+					joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, text);
+					hangul += makeHangul(chosungIdx, joongsungIdx, 0);
+
+					eraseAndInsert(hangul, false);
+				}
+			}
+			else if (!strcmp(jongsung, " ") && charType == KoreanCharType::JAEUM)
+			{
+				int jongsungIdx = findIndex(KOREAN_JONGSUNG_LIST, text);
+
+				if (jongsungIdx != -1)
+				{
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, chosung);
+					int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, joongsung);
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, jongsungIdx);
+
+					eraseAndInsert(hangul);
+				}
+				else
+				{
+					componentText.insert(componentCursor, text);
+				}
+			}
+			else if (!strcmp(jongsung, " ") && charType == KoreanCharType::MOEUM)
+			{
+				std::string combine = std::string(joongsung) + text;
+
+				int idx = findIndex(KOREAN_IJUNG_MOEUM_COMBINATIONS, combine.c_str());
+				if (idx != -1)
+				{
+					int chosungIdx = findIndex(KOREAN_CHOSUNG_LIST, chosung);
+					int joongsungIdx = findIndex(KOREAN_JOONGSUNG_LIST, KOREAN_IJUNG_MOEUM_LIST.at(idx));
+					std::string hangul = makeHangul(chosungIdx, joongsungIdx, 0);
+
+					eraseAndInsert(hangul);
+				}
+				else
+				{
+					componentText.insert(componentCursor, text);
+				}
+			}
+
+			size_t newCursor = nextCursor(componentText, componentCursor);
+			componentCursor = (unsigned int)newCursor;
+		}
+		// koreanTextInput
+
 		const std::string boolToString(bool value, bool uppercase)
 		{
 			if (uppercase)

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -32,7 +32,26 @@ namespace Utils
 		std::string join(const std::vector<std::string>& items, std::string separator);
         int			compareIgnoreCase(const std::string& name1, const std::string& name2);
 
-		bool           isKorean(const unsigned int uni);
+		// for Korean text input
+		const std::vector<const char*> KOREAN_CHOSUNG_LIST = { "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ" };
+		const std::vector<const char*> KOREAN_JOONGSUNG_LIST = { "ㅏ", "ㅐ", "ㅑ", "ㅒ", "ㅓ", "ㅔ", "ㅕ", "ㅖ", "ㅗ", "ㅘ", "ㅙ", "ㅚ", "ㅛ", "ㅜ", "ㅝ", "ㅞ", "ㅟ", "ㅠ", "ㅡ", "ㅢ", "ㅣ" };
+		const std::vector<const char*> KOREAN_JONGSUNG_LIST = { " ", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ" };
+		const std::vector<const char*> KOREAN_GYEOP_BATCHIM_LIST = { "ㄳ", "ㄵ", "ㄶ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅄ" };
+		const std::vector<const char*> KOREAN_GYEOP_BATCHIM_COMBINATIONS = { "ㄱㅅ", "ㄴㅈ", "ㄴㅎ", "ㄹㄱ", "ㄹㅁ", "ㄹㅂ", "ㄹㅅ", "ㄹㅌ", "ㄹㅍ", "ㄹㅎ", "ㅂㅅ" };
+		const std::vector<const char*> KOREAN_IJUNG_MOEUM_LIST = { "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ" };
+		const std::vector<const char*> KOREAN_IJUNG_MOEUM_COMBINATIONS = { "ㅗㅏ", "ㅗㅐ", "ㅗㅣ", "ㅜㅓ", "ㅜㅔ", "ㅜㅣ", "ㅡㅣ" };
+		enum KoreanCharType : unsigned int
+		{
+			NONE = 0,
+			JAEUM = 1,
+			MOEUM = 2,
+		};
+		bool            isKorean(const unsigned int uni);
+		bool            isKorean(const char* _string, bool checkFirstChar = true);
+		KoreanCharType  getKoreanCharType(const char* _string);
+		bool            splitHangulSyllable(const char* input, const char** chosung, const char** joongsung = nullptr, const char** jongsung = nullptr);
+		void            koreanTextInput(const char* text, std::string& componentText, unsigned int& componentCursor);
+		// end Korean text input
 
 #if defined(_WIN32)
 		const std::string convertFromWideString(const std::wstring wstring);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b58a0f24-90eb-4afb-9046-e3456b2fca7b)
![image](https://github.com/user-attachments/assets/57ce87fc-ff28-4825-a80b-a88c366c9917)


- Korean(Hangul) input is now supported, and the altedShifted state has been added, allowing for more diverse input.
- Fix incorrect character display for multi-byte characters in "JUMP TO..." and implement Korean character support.
- It also fixes the issue where the French (kbFr) keyboard was not displayed on arkos.

I have also tested it on arkos.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1858

Includes two dependency commits.
from https://github.com/batocera-linux/batocera-emulationstation/commit/495a6d584218e0c1fd6302df44c01033e332d4b7
from https://github.com/batocera-linux/batocera-emulationstation/commit/99be6a915592c25df4a5cec102c10195b237b10f
