### PR TITLE
[PopupKeyboard] Cursor move bug fix

### DIFF
--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -275,6 +275,11 @@ void ComponentGrid::resetCursor()
 	}
 }
 
+Vector2i ComponentGrid::getCursor()
+{
+	return mCursor;
+}
+
 bool ComponentGrid::moveCursor(Vector2i dir)
 {
 	assert(dir.x() || dir.y());
@@ -325,6 +330,16 @@ bool ComponentGrid::moveCursor(Vector2i dir)
 	//failed to find another focusable element in this direction
 	mCursor = origCursor;
 	return false;
+}
+
+void ComponentGrid::setCursorTo(Vector2i pos)
+{
+	assert(pos.x() >= 0 && pos.x() < mGridSize.x() && pos.y() >= 0 && pos.y() < mGridSize.y());
+
+	const Vector2i origCursor = mCursor;
+	mCursor = pos;
+
+	onCursorMoved(origCursor, pos);
 }
 
 void ComponentGrid::onFocusLost()

--- a/es-core/src/components/ComponentGrid.h
+++ b/es-core/src/components/ComponentGrid.h
@@ -55,7 +55,9 @@ public:
 	void setColWidthPerc(int col, float width, bool update = true); // if update is false, will not call an onSizeChanged() which triggers a (potentially costly) repositioning + resizing of every element
 	void setRowHeightPerc(int row, float height, bool update = true); // if update is false, will not call an onSizeChanged() which triggers a (potentially costly) repositioning + resizing of every element
 
+	Vector2i getCursor();
 	bool moveCursor(Vector2i dir);
+	void setCursorTo(Vector2i pos);
 	void setCursorTo(const std::shared_ptr<GuiComponent>& comp);
 
 	inline std::shared_ptr<GuiComponent> getSelectedComponent()

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -251,7 +251,8 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		{		
 			if (mGrid.getSelectedComponent() == mKeyboardGrid)
 			{
-				mKeyboardGrid->moveCursor(Vector2i(kbUs[0].size() - 1, 0));
+				Vector2i curCursor = mKeyboardGrid->getCursor();
+				mKeyboardGrid->setCursorTo(Vector2i(kbUs[0].size() - 1, curCursor.y()));
 				return true;
 			}
 		}
@@ -259,7 +260,8 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		{
 			if (mGrid.getSelectedComponent() == mKeyboardGrid)
 			{
-				mKeyboardGrid->moveCursor(Vector2i(-kbUs[0].size() + 1, 0));
+				Vector2i curCursor = mKeyboardGrid->getCursor();
+				mKeyboardGrid->setCursorTo(Vector2i(0, curCursor.y()));
 				return true;
 			}
 		}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/28cd793f-f089-4192-acc7-e2092d03621a)

When using the PopupKeyboard,

if you start at the blue position and move the cursor, it functions normally.
However, if you start at the red position and attempt to move the cursor, it does not move at all.

This issue appears to occur when the cursorGridEntry's dim is greater than 1.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1873