### PR TITLE
Fix SystemView page navigation crash when few systems are visible

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -385,12 +385,14 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pagedown", input))
 			{
-				int cursor = mCursor + 10;
-				if (cursor < 0)
-					cursor += (int)mEntries.size();
+				const int sz = (int)mEntries.size();
+				if (sz <= 1)
+					return true;
 
-				if (cursor >= (int)mEntries.size())
-					cursor -= (int)mEntries.size();
+				const int step = (sz > 10) ? 10 : 1;
+				int cursor = mCursor + step;
+				cursor %= sz;
+				if (cursor < 0) cursor += sz;
 
 				auto sd = mEntries.at(cursor).object;
 				ViewController::get()->goToSystemView(sd, true);
@@ -399,11 +401,14 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pageup", input))
 			{
-				int cursor = mCursor - 10;
-				if (cursor < 0)
-					cursor += (int)mEntries.size();
-				if (cursor >= (int)mEntries.size())
-					cursor -= (int)mEntries.size();
+				const int sz = (int)mEntries.size();
+				if (sz <= 1)
+					return true;
+
+				const int step = (sz > 10) ? 10 : 1;
+				int cursor = mCursor - step;
+				cursor %= sz;
+				if (cursor < 0) cursor += sz;
 
 				auto sd = mEntries.at(cursor).object;
 				ViewController::get()->goToSystemView(sd, true);
@@ -427,12 +432,14 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pagedown", input) && mEntries.size() > 10)
 			{
-				int cursor = mCursor + 10;
-				if (cursor < 0)
-					cursor += (int)mEntries.size();
+				const int sz = (int)mEntries.size();
+				if (sz <= 1)
+					return true;
 
-				if (cursor >= (int)mEntries.size())
-					cursor -= (int)mEntries.size();
+				const int step = (sz > 10) ? 10 : 1;
+				int cursor = mCursor + step;
+				cursor %= sz;
+				if (cursor < 0) cursor += sz;
 
 				auto sd = mEntries.at(cursor).object;
 				ViewController::get()->goToSystemView(sd, true);
@@ -441,11 +448,14 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pageup", input) && mEntries.size() > 10)
 			{
-				int cursor = mCursor - 10;
-				if (cursor < 0)
-					cursor += (int)mEntries.size();
-				if (cursor >= (int)mEntries.size())
-					cursor -= (int)mEntries.size();
+				const int sz = (int)mEntries.size();
+				if (sz <= 1)
+					return true;
+
+				const int step = (sz > 10) ? 10 : 1;
+				int cursor = mCursor - step;
+				cursor %= sz;
+				if (cursor < 0) cursor += sz;
 
 				auto sd = mEntries.at(cursor).object;
 				ViewController::get()->goToSystemView(sd, true);


### PR DESCRIPTION
## Summary

On ArkOS, pressing **L/R** in the **SystemView** (system carousel) can cause EmulationStation to crash/restart when only a small number of systems are visible (e.g. after hiding many systems). This PR fixes the page navigation index calculation to prevent out-of-range access and ensures page navigation still works correctly with few visible systems.

## Environment

- Device: **G350 (RK3326)**
- Image: **dArkOS_G350_trixie_01012026.img**
- EmulationStation fork: **EmulationStation-fcamod**

## Steps to Reproduce

1. Flash and boot **dArkOS_G350_trixie_01012026.img**.
2. Press **L** or **R** (mapped to **pageup/pagedown** for quick paging).

## Actual Result

EmulationStation **crashes/restarts** (appears as ES restarting immediately).

## Expected Result

EmulationStation should **not** crash. Paging with L/R should move selection safely (and still support “jump by 10” behavior when many systems are visible).

## Root Cause

`SystemView::input()` handled `pageup/pagedown` by computing a target cursor and then calling `mEntries.at(cursor)`. When most systems are hidden, `mEntries` may be very small (or transiently empty during reload/visibility changes), and the original cursor math could resolve to an invalid index, causing `std::out_of_range` and a process restart.

## Fix

- Guard against `mEntries.size() <= 1` to avoid invalid access.
- Use safe modulo wrapping for cursor calculation.
- When the visible system count is small, reduce page step to keep navigation responsive and avoid “no-op” paging.

## Testing

- Reproduced the issue on **G350** with **dArkOS_G350_trixie_01012026.img**.
- After this change, pressing **L/R** no longer crashes/restarts ES, and navigation behaves as expected with both few and many visible systems.