### PR TITLE
GuiTools: add gamelist.xml name lookup support

### DIFF
--- a/es-app/src/guis/GuiTools.cpp
+++ b/es-app/src/guis/GuiTools.cpp
@@ -1,4 +1,6 @@
 #include <string>
+#include <vector>
+#include <algorithm>
 #include "AudioManager.h"
 #include "VolumeControl.h"
 #include "guis/GuiTools.h"
@@ -7,9 +9,6 @@
 #include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
 #include "platform.h"
-
-#include <fstream>
-#include <algorithm>
 
 // ------------------- SubMenuWrapper -------------------
 class SubMenuWrapper : public GuiComponent
@@ -42,13 +41,14 @@ private:
 
 // ------------------- GuiTools -------------------
 GuiTools::GuiTools(Window* window)
-    : GuiComponent(window), mMenu(window, _("OPTIONS"))
+    : GuiComponent(window)
+    , mMenu(window, _("OPTIONS"))
+    , mResolver(new NameResolver("/opt/system"))
 {
     addChild(&mMenu);
 
     addScriptsToMenu(mMenu, "/opt/system");
 
-    // Root BACK button
     mMenu.addButton(_("BACK"), "back", [this] { delete this; });
 
     Vector2f screenSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
@@ -68,95 +68,58 @@ GuiTools::~GuiTools()
 {
 }
 
-// ------------------- addScriptsToMenu -------------------
 bool GuiTools::addScriptsToMenu(MenuComponent& menu, const std::string& folderPath)
 {
     auto items = Utils::FileSystem::getDirContent(folderPath);
-    std::vector<std::pair<std::string, SubMenuWrapper*> > folderWrappers;
+    std::vector<std::pair<std::string, SubMenuWrapper*> > folders;
     std::vector<std::pair<std::string, std::string> > scripts;
 
     for (auto& item : items)
     {
-        std::string name = Utils::FileSystem::getFileName(item);
-        std::string fullPath = item;
+        std::string fileName = Utils::FileSystem::getFileName(item);
 
-        if (Utils::FileSystem::isDirectory(fullPath))
+        if (Utils::FileSystem::isDirectory(item))
         {
-            std::string folderDisplayName = _U("\uF07B ") + name;
-            MenuComponent* subMenu = new MenuComponent(mWindow, name);
-            bool hasItems = addScriptsToMenu(*subMenu, fullPath);
+            MenuComponent* subMenu = new MenuComponent(mWindow, fileName);
+            bool hasItems = addScriptsToMenu(*subMenu, item);
 
             if (hasItems)
             {
                 SubMenuWrapper* wrapper = new SubMenuWrapper(mWindow, subMenu);
 
-			    Vector2f screenSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
-			    Vector2f menuSize = subMenu->getSize();
+                Vector2f screenSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+                Vector2f menuSize = subMenu->getSize();
 
-			    if (screenSize.x() >= 1024 && screenSize.y() >= 600)
-			    {
-			        Vector3f pos;
-			        pos[0] = (screenSize.x() - menuSize.x()) / 2.0f;
-			        pos[1] = (screenSize.y() - menuSize.y()) / 2.0f;
-			        pos[2] = 0;
-			        subMenu->setPosition(pos);
-    			}
+                if (screenSize.x() >= 1024 && screenSize.y() >= 600)
+                {
+                    Vector3f pos;
+                    pos[0] = (screenSize.x() - menuSize.x()) / 2.0f;
+                    pos[1] = (screenSize.y() - menuSize.y()) / 2.0f;
+                    pos[2] = 0;
+                    subMenu->setPosition(pos);
+                }
 
-                // On-screen BACK button closes submenu
                 subMenu->addButton(_("BACK"), "back", [wrapper] {
                     wrapper->close();
                 });
 
-                folderWrappers.push_back(std::make_pair(folderDisplayName, wrapper));
+                std::string displayName = _U("\uF07B ") + mResolver->resolve(item);
+                folders.push_back(std::make_pair(displayName, wrapper));
             }
             else
             {
                 delete subMenu;
             }
         }
-        else if (Utils::String::toLower(Utils::FileSystem::getExtension(name)) == ".sh")
+        else if (Utils::String::toLower(Utils::FileSystem::getExtension(fileName)) == ".sh")
         {
-            std::string displayName = Utils::FileSystem::getStem(name);
-
-            // .name sidecar
-            std::string nameFile = fullPath + ".name";
-            if (Utils::FileSystem::exists(nameFile))
-            {
-                std::ifstream f(nameFile.c_str());
-                if (f)
-                    std::getline(f, displayName);
-            }
-            else
-            {
-                // First 10 lines: look for "# NAME:"
-                std::ifstream f(fullPath.c_str());
-                if (f)
-                {
-                    std::string line;
-                    const std::string marker = "# NAME:";
-                    int linesChecked = 0;
-                    while (linesChecked < 10 && std::getline(f, line))
-                    {
-                        linesChecked++;
-                        if (line.find(marker) == 0)
-                        {
-                            std::string candidate = Utils::String::trim(line.substr(marker.size()));
-                            if (!candidate.empty())
-                            {
-                                displayName = candidate;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            std::string scriptDisplayName = _U("\uF013 ") + displayName;
-            scripts.push_back(std::make_pair(scriptDisplayName, fullPath));
+            std::string displayName = _U("\uF013 ") + mResolver->resolve(item);
+            scripts.push_back(std::make_pair(displayName, item));
         }
     }
 
     // Sort case-insensitive
-    std::sort(folderWrappers.begin(), folderWrappers.end(),
+    std::sort(folders.begin(), folders.end(),
         [](const std::pair<std::string, SubMenuWrapper*>& a,
            const std::pair<std::string, SubMenuWrapper*>& b) {
             return Utils::String::toLower(a.first) < Utils::String::toLower(b.first);
@@ -168,37 +131,33 @@ bool GuiTools::addScriptsToMenu(MenuComponent& menu, const std::string& folderPa
             return Utils::String::toLower(a.first) < Utils::String::toLower(b.first);
         });
 
-    // Add folder entries
-    for (size_t i = 0; i < folderWrappers.size(); ++i)
+    // Add folder entries - capture only the pointer, not the whole vector
+    for (size_t i = 0; i < folders.size(); ++i)
     {
-        const std::string folderName = folderWrappers[i].first;
-        SubMenuWrapper* wrapper = folderWrappers[i].second;
-
-        menu.addEntry(folderName, true, [this, wrapper] {
-            mWindow->pushGui(wrapper);
+        SubMenuWrapper* wrapperPtr = folders[i].second;
+        std::string entryName = folders[i].first;
+        menu.addEntry(entryName, true, [this, wrapperPtr] {
+            mWindow->pushGui(wrapperPtr);
         }, "");
     }
 
-    // Add script entries
+    // Add script entries - capture only the script path, not the whole vector
     for (size_t i = 0; i < scripts.size(); ++i)
     {
-        const std::string displayName = scripts[i].first;
-        const std::string path = scripts[i].second;
-
-        menu.addEntry(displayName, false, [this, path] {
-            launchTool(path);
+        std::string scriptPath = scripts[i].second;
+        std::string entryName = scripts[i].first;
+        menu.addEntry(entryName, false, [this, scriptPath] {
+            launchTool(scriptPath);
         }, "");
     }
 
-    return (!folderWrappers.empty() || !scripts.empty());
+    return (!folders.empty() || !scripts.empty());
 }
 
-// ------------------- launchTool -------------------
 void GuiTools::launchTool(const std::string& script)
 {
     AudioManager::getInstance()->deinit();
     VolumeControl::getInstance()->deinit();
-    // Hide ES temporarily
     mWindow->deinit(true);
 
     system("sudo chmod 666 /dev/tty1");
@@ -206,16 +165,13 @@ void GuiTools::launchTool(const std::string& script)
     int ret = system(cmd.c_str());
     (void)ret;
 
-    // Clear framebuffer in case script left garbage
     system("setterm -clear all > /dev/tty1");
 
-    // Restore ES
     mWindow->init(true);
     VolumeControl::getInstance()->init();
     AudioManager::getInstance()->init();
 }
 
-// ------------------- input -------------------
 bool GuiTools::input(InputConfig* config, Input input)
 {
     if (input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
@@ -235,7 +191,6 @@ bool GuiTools::input(InputConfig* config, Input input)
     return GuiComponent::input(config, input);
 }
 
-// ------------------- render -------------------
 void GuiTools::render(const Transform4x4f& parentTrans)
 {
     GuiComponent::render(parentTrans);

--- a/es-app/src/guis/GuiTools.h
+++ b/es-app/src/guis/GuiTools.h
@@ -1,27 +1,28 @@
-#include <string>
 #pragma once
 #ifndef ES_APP_GUIS_GUITOOLS_H
 #define ES_APP_GUIS_GUITOOLS_H
 
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
+#include "utils/NameResolver.h"
+
+#include <memory>
 
 class GuiTools : public GuiComponent
 {
 public:
     GuiTools(Window* window);
-    ~GuiTools() override;   // ✅ destructor matches .cpp
+    ~GuiTools() override;
 
     bool input(InputConfig* config, Input input) override;
-
-    void render(const Transform4x4f& parentTrans) override;   // ✅ render override
+    void render(const Transform4x4f& parentTrans) override;
 
 private:
     bool addScriptsToMenu(MenuComponent& menu, const std::string& folderPath);
     void launchTool(const std::string& script);
 
     MenuComponent mMenu;
+    std::unique_ptr<NameResolver> mResolver;
 };
 
 #endif // ES_APP_GUIS_GUITOOLS_H
-

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -87,6 +87,7 @@ set(CORE_HEADERS
 
 	# Utils
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/FileSystemUtil.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/NameResolver.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/StringUtil.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ThreadPool.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/TimeUtil.h
@@ -176,6 +177,7 @@ set(CORE_SOURCES
 
 	# Utils
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/FileSystemUtil.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/NameResolver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/StringUtil.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ThreadPool.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/TimeUtil.cpp

--- a/es-core/src/utils/NameResolver.cpp
+++ b/es-core/src/utils/NameResolver.cpp
@@ -1,0 +1,209 @@
+#include "utils/NameResolver.h"
+#include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
+#include "pugixml/src/pugixml.hpp"
+
+#include <fstream>
+#include <sys/stat.h>
+#include <ctime>
+
+NameResolver::NameResolver(const std::string& rootPath)
+    : mRootPath(rootPath)
+    , mLastModified(0)
+    , mLastCheckTime(0)
+    , mLoaded(false)
+{
+    // Normalize root path: remove trailing slash
+    while (!mRootPath.empty() && mRootPath.back() == '/')
+        mRootPath.pop_back();
+
+    mGamelistPath = mRootPath + "/gamelist.xml";
+    loadGamelist();
+}
+
+void NameResolver::loadGamelist()
+{
+    mNameMap.clear();
+    mLoaded = false;
+    mLastModified = 0;
+
+    if (!Utils::FileSystem::exists(mGamelistPath))
+        return;
+
+    // Record mtime
+    struct stat st;
+    if (stat(mGamelistPath.c_str(), &st) == 0)
+        mLastModified = st.st_mtime;
+
+    pugi::xml_document doc;
+    pugi::xml_parse_result result = doc.load_file(mGamelistPath.c_str());
+    if (!result)
+        return;
+
+    pugi::xml_node gameList = doc.child("gameList");
+    if (!gameList)
+        return;
+
+    // Parse <folder> entries
+    for (pugi::xml_node folder = gameList.child("folder"); folder; folder = folder.next_sibling("folder"))
+    {
+        std::string path = Utils::String::trim(folder.child("path").text().as_string());
+        std::string name = Utils::String::trim(folder.child("name").text().as_string());
+
+        if (!path.empty() && !name.empty())
+        {
+            // Normalize: remove leading "./"
+            if (path.size() > 2 && path[0] == '.' && path[1] == '/')
+                path = path.substr(2);
+            mNameMap[path] = name;
+        }
+    }
+
+    // Parse <game> entries
+    for (pugi::xml_node game = gameList.child("game"); game; game = game.next_sibling("game"))
+    {
+        std::string path = Utils::String::trim(game.child("path").text().as_string());
+        std::string name = Utils::String::trim(game.child("name").text().as_string());
+
+        if (!path.empty() && !name.empty())
+        {
+            // Normalize: remove leading "./"
+            if (path.size() > 2 && path[0] == '.' && path[1] == '/')
+                path = path.substr(2);
+            mNameMap[path] = name;
+        }
+    }
+
+    mLoaded = true;
+}
+
+void NameResolver::reload()
+{
+    mResolveCache.clear();
+    loadGamelist();
+}
+
+void NameResolver::checkAndReloadIfNeeded()
+{
+    // Rate limit: only check stat every 2 seconds
+    std::time_t now = std::time(nullptr);
+    if (now - mLastCheckTime < 2)
+        return;
+    mLastCheckTime = now;
+
+    if (mGamelistPath.empty())
+        return;
+
+    struct stat st;
+    if (stat(mGamelistPath.c_str(), &st) != 0)
+    {
+        // File no longer exists
+        if (mLoaded)
+        {
+            loadGamelist();
+            mResolveCache.clear();
+        }
+        return;
+    }
+
+    if (st.st_mtime != mLastModified)
+    {
+        loadGamelist();
+        mResolveCache.clear();
+    }
+}
+
+std::string NameResolver::normalizeRelative(const std::string& fullPath) const
+{
+    // Check if fullPath starts with rootPath + "/"
+    std::string prefix = mRootPath + "/";
+    if (fullPath.rfind(prefix, 0) == 0)
+        return fullPath.substr(prefix.size());
+
+    // Fallback: return filename only
+    return Utils::FileSystem::getFileName(fullPath);
+}
+
+std::string NameResolver::readSidecar(const std::string& fullPath) const
+{
+    std::string nameFile = fullPath + ".name";
+    if (!Utils::FileSystem::exists(nameFile))
+        return "";
+
+    std::ifstream f(nameFile.c_str());
+    if (!f)
+        return "";
+
+    std::string name;
+    std::getline(f, name);
+    return Utils::String::trim(name);
+}
+
+std::string NameResolver::readScriptComment(const std::string& fullPath) const
+{
+    std::ifstream f(fullPath.c_str());
+    if (!f)
+        return "";
+
+    std::string line;
+    const std::string marker = "# NAME:";
+    int linesChecked = 0;
+
+    while (linesChecked < 10 && std::getline(f, line))
+    {
+        linesChecked++;
+        std::string trimmed = Utils::String::trim(line);
+        if (trimmed.rfind(marker, 0) == 0)
+        {
+            std::string candidate = Utils::String::trim(trimmed.substr(marker.size()));
+            if (!candidate.empty())
+                return candidate;
+        }
+    }
+
+    return "";
+}
+
+std::string NameResolver::getFallbackName(const std::string& fullPath) const
+{
+    return Utils::FileSystem::getStem(fullPath);
+}
+
+std::string NameResolver::resolve(const std::string& fullPath)
+{
+    // Check cache first
+    auto itCache = mResolveCache.find(fullPath);
+    if (itCache != mResolveCache.end())
+        return itCache->second;
+
+    // Check if gamelist.xml changed and reload if needed
+    checkAndReloadIfNeeded();
+
+    std::string result;
+
+    // Priority 1: gamelist.xml
+    std::string relativePath = normalizeRelative(fullPath);
+    auto it = mNameMap.find(relativePath);
+    if (it != mNameMap.end())
+    {
+        result = it->second;
+    }
+    else
+    {
+        // Priority 2: .name sidecar file
+        result = readSidecar(fullPath);
+        if (result.empty())
+        {
+            // Priority 3: # NAME: in script comments
+            result = readScriptComment(fullPath);
+            if (result.empty())
+            {
+                // Priority 4: filename fallback
+                result = getFallbackName(fullPath);
+            }
+        }
+    }
+
+    mResolveCache[fullPath] = result;
+    return result;
+}

--- a/es-core/src/utils/NameResolver.h
+++ b/es-core/src/utils/NameResolver.h
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef ES_CORE_UTILS_NAMERESOLVER_H
+#define ES_CORE_UTILS_NAMERESOLVER_H
+
+#include <string>
+#include <unordered_map>
+#include <ctime>
+
+class NameResolver
+{
+public:
+    explicit NameResolver(const std::string& rootPath);
+    ~NameResolver() = default;
+
+    // Resolve display name for a given full path
+    // Priority: gamelist.xml > .name sidecar > script comment > filename
+    std::string resolve(const std::string& fullPath);
+
+    // Check if gamelist.xml was loaded
+    bool isLoaded() const { return mLoaded; }
+
+    // Force reload gamelist.xml
+    void reload();
+
+private:
+    void loadGamelist();
+    void checkAndReloadIfNeeded();
+    std::string normalizeRelative(const std::string& fullPath) const;
+    std::string readSidecar(const std::string& fullPath) const;
+    std::string readScriptComment(const std::string& fullPath) const;
+    std::string getFallbackName(const std::string& fullPath) const;
+
+    std::string mRootPath;
+    std::string mGamelistPath;
+    std::unordered_map<std::string, std::string> mNameMap;
+    std::unordered_map<std::string, std::string> mResolveCache;
+    std::time_t mLastModified;
+    std::time_t mLastCheckTime;
+    bool mLoaded;
+};
+
+#endif // ES_CORE_UTILS_NAMERESOLVER_H


### PR DESCRIPTION
  ---

  Overview

  This PR introduces a dedicated NameResolver component for script display name resolution, improving separation
  of concerns, performance, and maintainability.

  Motivation

  Previously, name resolution logic was embedded in GuiTools, mixing UI responsibilities with file I/O and
  parsing. This caused:
   - Repeated file reads during menu construction
   - Tight coupling between UI and name parsing
   - No automatic reload when gamelist.xml was modified

  Changes

  1. New NameResolver Class
   - Resolves display names with priority: gamelist.xml → .name sidecar → # NAME: comment → filename
   - Caches gamelist.xml entries in std::unordered_map for O(1) lookup
   - Per-path resolution cache to avoid repeated I/O

  2. mtime-Based Auto Reload
   - Monitors gamelist.xml modification time
   - Automatically reloads when modification time changes
   - stat() calls are throttled (2-second window) to avoid excessive system calls

  3. Performance
   - Script files are parsed once per session per path unless the cache is cleared
   - gamelist.xml only reloaded when modified
   - No repeated disk I/O during menu construction

  4. UI Layer Cleanup
   - GuiTools delegates all name resolution to NameResolver

  Usage Example

   ```xml
   <!-- /opt/system/gamelist.xml -->
   <gameList>
     <folder>
       <path>./Tools</path>
       <name>Tools</name>
     </folder>
     <game>
       <path>./backup.sh</path>
       <name>Backup System</name>
     </game>
   </gameList>
   ```

  Compatibility

   - Fully backward compatible — gracefully falls back to .name, script header, or filename if gamelist.xml is absent
   - No breaking changes

  ---