### PR TITLE
Fix battery icon not updating after theme reload

### DIFF
--- a/es-core/src/components/ControllerActivityComponent.cpp
+++ b/es-core/src/components/ControllerActivityComponent.cpp
@@ -385,7 +385,10 @@ void ControllerActivityComponent::applyTheme(const std::shared_ptr<ThemeData>& t
 		}
 	}
 
-	onSizeChanged();
+    onSizeChanged();
+    mCurrentBatteryTexture.clear();
+    mBatteryImage = nullptr;
+    mBatteryInfo.level = -1;
 }
 
 /*void ControllerActivityComponent::updateNetworkInfo()

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <stdarg.h>
+#include <stdint.h>
 #include <cstring>
 #include "utils/han.h"
 


### PR DESCRIPTION
This PR fixes a bug where the battery indicator did not update after a theme loaded or applied unless the battery level changed.

- **Problem**: The battery indicator only updated when the battery level changed. When a theme was loaded or applied, the old battery icon remained until the battery percentage (or status) changed.

- **Cause**: `updateBatteryInfo()` returned early if the battery state did not change, preventing the icon from being re-evaluated using the new theme assets.

- **Solution**: Invalidate the cached battery texture when `applyTheme()` runs so the correct icon is loaded immediately after a theme change.