### PR TITLE
Add TheGamesDB API key input in scraper settings

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -349,6 +349,7 @@ void GuiMenu::openScraperSettings()
 		scrape_ratings->setState(Settings::getInstance()->getBool("ScrapeRatings"));
 		s->addWithLabel(_("SCRAPE RATINGS"), scrape_ratings); // batocera
 		s->addSaveFunc([scrape_ratings] { Settings::getInstance()->setBool("ScrapeRatings", scrape_ratings->getState()); });
+		createInputTextRow(s, _("API KEY"), "GamesDBApiKey", false);
 	}
 
 	// scrape now

--- a/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
@@ -11,6 +11,7 @@
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include "Log.h"
+#include "Settings.h"
 
 #ifdef GAMESDB_APIKEY
 using namespace rapidjson;
@@ -52,7 +53,11 @@ std::string getScrapersResouceDir()
 }
 
 
-   std::string TheGamesDBJSONRequestResources::getApiKey() const { return GAMESDB_APIKEY; }
+   std::string TheGamesDBJSONRequestResources::getApiKey() const {
+	std::string userKey = Settings::getInstance()->getString("GamesDBApiKey");
+	if (!userKey.empty()) return userKey;
+	return GAMESDB_APIKEY;
+}
 
 
 void TheGamesDBJSONRequestResources::prepare()


### PR DESCRIPTION
Currently TheGamesDB API key is compiled into the binary, which means users 
cannot use their own key and are limited by the shared quota.

Changes:
- GuiMenu.cpp - added "API KEY" text input field in scraper settings UI 
  when TheGamesDB is selected as the scraper source
- GamesDBJSONScraperResources.cpp - getApiKey() now checks Settings for 
  user-provided "GamesDBApiKey" first, falls back to compiled-in 
  GAMESDB_APIKEY if empty

This allows users to enter their own TheGamesDB API key without recompiling,
and removes dependency on the shared quota of the compiled-in key.